### PR TITLE
remove database default double

### DIFF
--- a/freeradio/settings.py
+++ b/freeradio/settings.py
@@ -95,7 +95,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'freeradio.wsgi.application'
 DATABASES = {
-    'default': env.db('DATABASE_URL'),
     'default': env.db(
         'DATABASE_URL',
         default='sqlite:///%s' % BASE_DIR.path('freeradio.sqlite')


### PR DESCRIPTION
fix an error that occurs when no database is provided in the .env file due to duplicate database default settings